### PR TITLE
Add start script with runtime/module configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ pip install -r requirements.txt || true   # ถ้าไฟล์นี้ยั
 pip install -r requirements-dev.txt
 # ตัวอย่างรัน (ปรับตาม entrypoint จริงของโปรเจกต์)
 python crystal_api_main.py  # หรือ uvicorn app:app --reload
+
+# หรือใช้สคริปต์ `start.sh` (รองรับการกำหนด runtime/module ผ่าน env var)
+APP_RUNTIME=python APP_MODULE=main:app ./start.sh
 ```
 
 ## Docker
@@ -26,6 +29,8 @@ docker run --rm -p 8000:8000 --env-file .env cosmic/framework:dev
 คัดลอกจาก `.env.example` ใส่ค่าเริ่มต้น:
 - `APP_ENV=dev`
 - `APP_PORT=8000`
+- `APP_RUNTIME=python` — เลือกรันผ่าน `uvicorn` (ค่าตั้งต้น)
+- `APP_MODULE=main:app` — ระบุโมดูล FastAPI (แก้ได้ตามโครงสร้างจริง)
 - เพิ่มคีย์อื่นที่โมดูลของพี่ใช้จริง (เช่น API keys)
 
 ## Makefile

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RUNTIME="${APP_RUNTIME:-python}"
+MODULE="${APP_MODULE:-main:app}"
+
+case "$RUNTIME" in
+  python|uvicorn)
+    exec uvicorn "$MODULE"
+    ;;
+  *)
+    echo "Unsupported APP_RUNTIME: $RUNTIME" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
- add a start.sh helper that runs uvicorn based on APP_RUNTIME and APP_MODULE
- document APP_RUNTIME/APP_MODULE usage in README

## Testing
- APP_RUNTIME=python ./start.sh

------
https://chatgpt.com/codex/tasks/task_e_68cba0c6547c832fa157f1b2732cc4dd