### PR TITLE
Add dockerignore to reduce Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.github
+node_modules
+__pycache__/
+*.pyc
+.env*
+build/
+dist/
+logs/
+coverage/
+*.log
+*.tmp


### PR DESCRIPTION
## Summary
- add a .dockerignore file to exclude development and build artifacts from Docker build contexts

## Testing
- docker build -t namo-test . *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cba0c6e0cc832f8caff424e13b28f0