### PR TITLE
Add root and health endpoints with tests

### DIFF
--- a/main.py
+++ b/main.py
@@ -23,6 +23,17 @@ app = FastAPI(
     servers=servers
 )
 
+
+@app.get("/", response_model=dict)
+async def root_status():
+    return {"ok": True, "service": "namo_cosmic_ai_framework"}
+
+
+@app.get("/health", response_model=dict)
+async def health_check():
+    return {"status": "healthy"}
+
+
 @app.post("/universal-endpoint")
 async def universal_api(input: UniversalInput):
     return {"status": "ok", "data_received": input.dict()}

--- a/tests/test_main_endpoints.py
+++ b/tests/test_main_endpoints.py
@@ -1,0 +1,18 @@
+from fastapi.testclient import TestClient
+
+from main import app
+
+
+client = TestClient(app)
+
+
+def test_root_endpoint():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"ok": True, "service": "namo_cosmic_ai_framework"}
+
+
+def test_health_endpoint():
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "healthy"}


### PR DESCRIPTION
## Summary
- add FastAPI routes for `/` and `/health` to provide service status responses
- create tests to validate the new endpoints return expected payloads

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68cba0c37844832f970f20e2b68afefb