### PR TITLE
Switch to distroless runtime and add start script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,41 @@
-# Base image
-FROM python:3.12-slim
+# syntax=docker/dockerfile:1
 
-# Set workdir
+# Stage: build Python environment
+FROM python:3.11-slim AS python-builder
+
+ENV VENV_PATH=/opt/venv
+
+RUN python -m venv ${VENV_PATH} \
+    && ${VENV_PATH}/bin/pip install --upgrade pip
+
+ENV PATH="${VENV_PATH}/bin:${PATH}"
+
 WORKDIR /app
 
-# Copy requirements
-COPY requirements.txt requirements.txt
-# Install dependencies
-RUN pip install --no-cache-dir -r requirements.txt
+COPY requirements.txt ./
 
-# Copy source code
+RUN pip install --no-cache-dir --upgrade wheel setuptools \
+    && pip install --no-cache-dir -r requirements.txt
+
+# Optional Node stage can be added here if a package.json exists in the project root.
+# FROM node:20-slim AS node-builder
+# WORKDIR /app
+# COPY package*.json ./
+# RUN npm install --production
+# COPY . .
+# RUN npm run build
+# The build output should then be copied from /app/dist (or similar) to /opt/node in the final stage.
+
+FROM gcr.io/distroless/python3-debian12
+
+ENV PATH="/opt/venv/bin:${PATH}"
+WORKDIR /app
+
+COPY --from=python-builder /opt/venv /opt/venv
+COPY --from=python-builder /bin/bash /bin/bash
+
 COPY . .
 
-# Expose port that Cloud Run will use
 EXPOSE 8080
 
-# Run app with uvicorn. Cloud Run will automatically set the PORT environment variable.
-# We listen on 0.0.0.0 to accept connections from outside the container.
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]
+CMD ["./start.sh"]

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+PORT="${PORT:-8080}"
+RUNTIME="${APP_RUNTIME:-python}"
+
+case "$RUNTIME" in
+  python)
+    exec uvicorn main:app --host 0.0.0.0 --port "$PORT"
+    ;;
+  *)
+    echo "Unsupported APP_RUNTIME: $RUNTIME" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
- build a dedicated Python virtual environment in a python:3.11-slim builder stage
- run the application from a new start.sh script on top of the gcr.io/distroless/python3-debian12 runtime
- document how an optional Node build stage can be inserted if a package.json is present

## Testing
- docker build -t namo-cosmic:dev . *(fails: docker not available in environment)*
- docker run --rm -p 8080:8080 -e APP_RUNTIME=python namo-cosmic:dev *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cba0cab9ac832fa33e4a0d4faf042b