### PR TITLE
Fix test imports for core modules

### DIFF
--- a/core_modules/__init__.py
+++ b/core_modules/__init__.py
@@ -1,0 +1,7 @@
+"""Core module package exposing emotional core and other subsystems."""
+
+__all__ = [
+    "EmotionalCore",
+]
+
+from .emotional_core import EmotionalCore

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Pytest configuration ensuring project root is importable."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
## Summary
- add a package initializer so `core_modules` exports `EmotionalCore`
- ensure pytest adds the repository root to `sys.path` so package imports resolve during collection

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cba506be48832f86c974e30c6deeff