### PR TITLE
Automate Cloud Run URL linking

### DIFF
--- a/README_CICD_WIF.md
+++ b/README_CICD_WIF.md
@@ -19,6 +19,8 @@ bash scripts/setup_wif.sh
   - `CLOUD_RUN_SERVICE` = `hello`
   - `ARTIFACT_REPO` = `namo`
 
-3) Push โค้ดขึ้น branch `main` → Action จะ build image (Cloud Build) และ deploy ไป Cloud Run อัตโนมัติ
+3) Push โค้ดขึ้น branch `main` → Action จะ build image (Cloud Build) และ deploy ไป Cloud Run อัตโนมัติ พร้อมตั้งค่า
+   env `SERVER_URL` ไปยังโดเมนของ Cloud Run (`https://hello-<PROJECT_NUMBER>.asia-southeast1.run.app`) เพื่อให้
+   FastAPI docs ชี้ URL ภายนอกถูกต้อง
 
 > หมายเหตุ: ครั้งแรกอาจต้อง enable APIs; workflow ทำให้แล้วแบบ idempotent

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,18 +7,20 @@ steps:
   - name: 'gcr.io/cloud-builders/docker'
     args: ['push', 'asia-southeast1-docker.pkg.dev/$PROJECT_ID/namo-repo/namoserver:latest']
 
-  # Step 3: Deploy ไป Cloud Run
+  # Step 3: Deploy ไป Cloud Run พร้อมคำนวณ URL สำหรับ SERVER_URL
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
-    entrypoint: gcloud
+    entrypoint: 'bash'
     args:
-      [
-        'run', 'deploy', 'hello',
-        '--image', 'asia-southeast1-docker.pkg.dev/$PROJECT_ID/namo-repo/namoserver:latest',
-        '--region', 'asia-southeast1',
-        '--platform', 'managed',
-        '--allow-unauthenticated',
-        '--set-env-vars=SERVER_URL=https://hello-185116032835.asia-southeast1.run.app'
-      ]
+      - '-c'
+      - |
+        PROJECT_NUMBER=$(gcloud projects describe "$PROJECT_ID" --format='value(projectNumber)')
+        SERVICE_URL="https://hello-${PROJECT_NUMBER}.asia-southeast1.run.app"
+        gcloud run deploy hello \
+          --image asia-southeast1-docker.pkg.dev/$PROJECT_ID/namo-repo/namoserver:latest \
+          --region asia-southeast1 \
+          --platform managed \
+          --allow-unauthenticated \
+          --set-env-vars "SERVER_URL=${SERVICE_URL}"
 
 images:
   - 'asia-southeast1-docker.pkg.dev/$PROJECT_ID/namo-repo/namoserver:latest'

--- a/deploy-cloudrun-wif.yml
+++ b/deploy-cloudrun-wif.yml
@@ -49,11 +49,21 @@ jobs:
         run: |
           gcloud builds submit --tag "$IMAGE" --project "$PROJECT_ID"
 
+      - name: Resolve Cloud Run service URL
+        id: resolve-service-url
+        run: |
+          PROJECT_NUMBER=$(gcloud projects describe "$PROJECT_ID" --format='value(projectNumber)')
+          SERVICE_URL="https://${SERVICE}-${PROJECT_NUMBER}.${REGION}.run.app"
+          echo "SERVICE_URL=$SERVICE_URL" >> "$GITHUB_ENV"
+
       - name: Deploy to Cloud Run
+        env:
+          SERVICE_URL: ${{ env.SERVICE_URL }}
         run: |
           gcloud run deploy "$SERVICE" \
             --image "$IMAGE" \
             --region "$REGION" \
             --project "$PROJECT_ID" \
             --platform managed \
-            --allow-unauthenticated
+            --allow-unauthenticated \
+            --set-env-vars "SERVER_URL=${SERVICE_URL}"


### PR DESCRIPTION
## Summary
- update Cloud Build deployment step to compute the Cloud Run URL and set SERVER_URL automatically
- extend the GitHub Actions WIF workflow to resolve the service URL and pass it as SERVER_URL during deployment
- document the automatic SERVER_URL configuration in the CI/CD walkthrough

## Testing
- `pytest` *(fails: missing optional modules core_modules & sanitized_core)*

------
https://chatgpt.com/codex/tasks/task_e_68cba8ae9e84832fbf0b58fbbcc8bf08