### PR TITLE
Fix: Add validation for negative limit in message retrieval

### DIFF
--- a/crystal_api_main.py
+++ b/crystal_api_main.py
@@ -1,5 +1,5 @@
 import os
-from fastapi import FastAPI, HTTPException, status
+from fastapi import Depends, FastAPI, HTTPException, status
 from pydantic import BaseModel
 from typing import List, Dict, Any
 
@@ -38,12 +38,18 @@ app = FastAPI(
 )
 
 # --- Global Service Initialization ---
-# Instantiate the memory service. This will be shared across all API requests.
-try:
-    memory_service = FirestoreMemory(project_id=GCP_PROJECT_ID)
-except Exception as e:
-    # If initialization fails (e.g., ADC not configured), the app should not start.
-    raise RuntimeError(f"Failed to initialize FirestoreMemory: {e}")
+# This function will act as a dependency to provide the memory service.
+def get_memory_service():
+    try:
+        # This part will be executed once per request that depends on it.
+        # For a more complex setup, you might initialize this once at startup.
+        yield FirestoreMemory(project_id=GCP_PROJECT_ID)
+    except Exception as e:
+        # If initialization fails, raise an HTTPException to be handled by FastAPI.
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=f"Failed to initialize FirestoreMemory: {e}"
+        )
 
 
 # --- API Endpoints ---
@@ -69,7 +75,11 @@ def health_check():
     summary="Add a message to a session",
     status_code=status.HTTP_201_CREATED
 )
-def add_message_to_session(session_id: str, message: Message):
+def add_message_to_session(
+    session_id: str,
+    message: Message,
+    memory_service: FirestoreMemory = Depends(get_memory_service)
+):
     """
     Adds a new message to the specified conversation session.
 
@@ -91,13 +101,22 @@ def add_message_to_session(session_id: str, message: Message):
     summary="Retrieve messages from a session",
     response_model=List[Dict[str, Any]] # Returns a list of message-like dictionaries
 )
-def get_messages_from_session(session_id: str, limit: int = 50):
+def get_messages_from_session(
+    session_id: str,
+    limit: int = 50,
+    memory_service: FirestoreMemory = Depends(get_memory_service)
+):
     """
     Retrieves the most recent messages from the specified conversation session.
 
     - **session_id**: The unique identifier for the conversation.
     - **limit**: The maximum number of messages to retrieve (defaults to 50).
     """
+    if limit < 1:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="The 'limit' parameter must be a positive integer."
+        )
     try:
         messages = memory_service.get_messages(session_id, limit=limit)
         return messages

--- a/tests/test_crystal_api_main.py
+++ b/tests/test_crystal_api_main.py
@@ -1,0 +1,80 @@
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import MagicMock
+
+# Set the environment variable required by the app BEFORE importing the app
+import os
+os.environ["GCP_PROJECT_ID"] = "test-project"
+
+# Import the app and the dependency function after setting the env var
+from crystal_api_main import app, get_memory_service
+
+
+@pytest.fixture
+def mock_memory_service():
+    """Fixture to create a mock of the FirestoreMemory service."""
+    service = MagicMock()
+    service.get_messages.return_value = [{"role": "user", "content": "hello"}]
+    service.add_message.return_value = None
+    return service
+
+
+@pytest.fixture
+def client(mock_memory_service):
+    """
+    Fixture to create a TestClient with the get_memory_service dependency
+    overridden to return our mock service.
+    """
+    # Define the override function
+    def override_get_memory_service():
+        yield mock_memory_service
+
+    # Apply the dependency override
+    app.dependency_overrides[get_memory_service] = override_get_memory_service
+
+    with TestClient(app) as c:
+        yield c
+
+    # Clean up the override after the test
+    del app.dependency_overrides[get_memory_service]
+
+
+def test_health_check(client):
+    """Tests the health check endpoint."""
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok", "project_id": "test-project"}
+
+
+def test_get_messages_invalid_limit_negative(client):
+    """Tests that a negative limit returns a 400 Bad Request."""
+    response = client.get("/sessions/test-session/messages?limit=-1")
+    assert response.status_code == 400
+    assert "must be a positive integer" in response.json()["detail"]
+
+
+def test_get_messages_invalid_limit_zero(client):
+    """Tests that a limit of zero returns a 400 Bad Request."""
+    response = client.get("/sessions/test-session/messages?limit=0")
+    assert response.status_code == 400
+    assert "must be a positive integer" in response.json()["detail"]
+
+
+def test_get_messages_valid_limit(client, mock_memory_service):
+    """Tests retrieving messages with a valid limit."""
+    response = client.get("/sessions/test-session/messages?limit=10")
+    assert response.status_code == 200
+    # Verify the mocked service was called correctly
+    mock_memory_service.get_messages.assert_called_once_with("test-session", limit=10)
+    # Verify the response from the mock is passed through
+    assert response.json() == [{"role": "user", "content": "hello"}]
+
+
+def test_add_message(client, mock_memory_service):
+    """Tests adding a message to a session."""
+    message_data = {"role": "user", "content": "test message"}
+    response = client.post("/sessions/test-session/messages", json=message_data)
+    assert response.status_code == 201
+    assert response.json() == {"status": "message added"}
+    # Verify the mocked service was called correctly
+    mock_memory_service.add_message.assert_called_once_with("test-session", "user", "test message")


### PR DESCRIPTION
The `get_messages_from_session` endpoint did not validate the `limit` query parameter. This allowed negative values to be passed to the underlying Firestore query, which would raise a `ValueError` and cause an unhandled 500 Internal Server Error.

This commit adds a validation check to ensure the `limit` is a positive integer, returning a 400 Bad Request if the validation fails.

Additionally, the `crystal_api_main.py` application was refactored to use FastAPI's dependency injection system for the `FirestoreMemory` service. This was necessary to properly mock the service in unit tests and improves the overall testability and design of the application.

A new test suite for this API, `tests/test_crystal_api_main.py`, has been added to verify the fix and ensure no regressions were introduced.